### PR TITLE
Added extended data types and attributes

### DIFF
--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/AttributeType.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/AttributeType.java
@@ -79,6 +79,20 @@ public final class AttributeType {
     }
 
     /**
+     * Returns the type at the given position.
+     *
+     * @param position integer in range [0, length of type - 1]
+     * @return the type at the given position
+     */
+    public int at(int position) {
+        if (position < 0 || position >= types.length) {
+            throw new IllegalArgumentException(String.format("Position must be in range [0, %d]", (types.length - 1)));
+        }
+
+        return types[position];
+    }
+
+    /**
      * Returns the number of components in this attribute type.
      * 
      * @return the number of components in this attribute type

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
@@ -50,6 +50,11 @@ public class ExtendedAttribute<D extends Data> extends Attribute<D> {
         this.extendedType = extendedType;
     }
 
+    /**
+     * Gets the extended attribute type.
+     *
+     * @return the extended attribute type (int in range [0, 255])
+     */
     public int getExtendedType() {
         return extendedType;
     }

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedAttribute.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * An extended attribute in the extended attribute space. An extended attribute is encapsulated in a
+ * {@link StandardAttribute} attribute containing {@link ExtendedData} data.
+ *
+ * @param <D> data type
+ */
+public class ExtendedAttribute<D extends Data> extends Attribute<D> {
+
+    private final int extendedType;
+
+    /**
+     * Constructs an extended attribute from an attribute type, extended type, and data.
+     *
+     * @param type the attribute type (int in range [0, 255])
+     * @param extendedType the attribute extended type (int in range [0, 255])
+     * @param data the attribute data
+     */
+    public ExtendedAttribute(int type, int extendedType, D data) {
+        super(new AttributeType(type, extendedType), data);
+
+        if (extendedType < 0 || extendedType > 255) {
+            throw new IllegalArgumentException("Extended type must be in range [0, 255]");
+        }
+
+        if (data.length() > 252) {
+            throw new IllegalArgumentException("Data length must be in range [0, 252]");
+        }
+
+        this.extendedType = extendedType;
+    }
+
+    public int getExtendedType() {
+        return extendedType;
+    }
+
+    /**
+     * Codec for a {@link ExtendedAttribute} of a particular data type ({@link D}). An instance of
+     * {@link ExtendedAttribute.Codec} is capable of decoding attributes with {@link ExtendedData} data into extended
+     * attributes with a particular data type.
+     *
+     * @param <D> the attribute data type used in the codec's target attribute
+     */
+    public static class Codec<D extends Data> implements AttributeCodec {
+
+        private final Factory<D> factory;
+
+        private final DataCodec<D> dataCodec;
+
+        /**
+         * Constructs a codec for a {@link ExtendedAttribute} using the given data codec and attribute instance factory.
+         *
+         * @param dataCodec the data codec
+         * @param factory the attribute instance factory
+         */
+        public Codec(DataCodec<D> dataCodec, Factory<D> factory) {
+            this.dataCodec = Objects.requireNonNull(dataCodec);
+            this.factory = Objects.requireNonNull(factory);
+        }
+
+        @Override
+        public int decode(CodecContext codecContext, Deque<Attribute<?>> attributeStack) {
+            @SuppressWarnings("unchecked")
+            Attribute<ExtendedData> attribute = (Attribute<ExtendedData>) attributeStack.removeFirst();
+
+            int type = attribute.getType().head();
+            int extendedType = attribute.getData().getExtendedType();
+            byte[] extData = attribute.getData().getExtData();
+
+            D data = dataCodec.decode(codecContext, extData);
+
+            if (data == null) {
+                attributeStack.addFirst(attribute);
+
+                // Inform the caller that this attribute shouldn't be processed anymore
+                return 1;
+            }
+
+            ExtendedAttribute<D> extendedAttribute = factory.build(type, extendedType, data);
+
+            attributeStack.addFirst(extendedAttribute);
+
+            return 0;
+        }
+
+        @Override
+        public void encode(CodecContext codecContext, Deque<Attribute<?>> attributeStack) {
+            @SuppressWarnings("unchecked")
+            ExtendedAttribute<D> extendedAttribute = (ExtendedAttribute<D>) attributeStack.removeFirst();
+
+            int extendedType = extendedAttribute.extendedType;
+            byte[] extData = dataCodec.encode(codecContext, extendedAttribute.getData());
+
+            ExtendedData extendedData = new ExtendedData(extendedType, extData);
+
+            StandardAttribute<ExtendedData> attribute = new StandardAttribute<>(extendedAttribute.getType().head(),
+                    extendedData);
+
+            attributeStack.addFirst(attribute);
+        }
+
+    }
+
+    /**
+     * Attribute factory that returns a concrete instance of {@link ExtendedAttribute} or a subtype when given a
+     * standard attribute type (integer in range [0, 255]), extended type (integer in range [0, 255]), and attribute
+     * data ({@link D}).
+     *
+     * @param <D> the attribute data type used in the codec's target attribute
+     */
+    @FunctionalInterface
+    public interface Factory<D extends Data> {
+
+        /**
+         * Builds a concrete instance of {@link ExtendedAttribute}.
+         *
+         * @param type the attribute type (integer in range [0, 255])
+         * @param extendedType the attribute extended type (integer in range [0, 255])
+         * @param data the attribute's data
+         *
+         * @return an instance of {@link ExtendedAttribute} or its subtypes with the provided type, extended type, and
+         * data
+         */
+        ExtendedAttribute<D> build(int type, int extendedType, D data);
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/ExtendedData.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * "extended" attribute data type. Extended data contains a nested attribute in the extended attribute space.
+ */
+public class ExtendedData extends ContainerData {
+
+    private final int extendedType;
+
+    private final byte[] extData;
+
+    /**
+     * Constructs extended data from a given extended attribute type and extended data byte array.
+     *
+     * @param extendedType the extended type
+     * @param extData the extended data
+     */
+    public ExtendedData(int extendedType, byte[] extData) {
+        if (extendedType < 0 || extendedType > 255) {
+            throw new IllegalArgumentException("Extended type must be in range [0, 255]");
+        }
+
+        Objects.requireNonNull(extData);
+
+        this.extendedType = extendedType;
+        this.extData = Arrays.copyOf(extData, extData.length);
+    }
+
+    @Override
+    public int length() {
+        return 1 + extData.length;
+    }
+
+    /**
+     * Get the extended type. For example, if this data contains a Frag-Status (241.1) attribute then the extended type
+     * will be 1.
+     *
+     * @return the extended type
+     */
+    public int getExtendedType() {
+        return extendedType;
+    }
+
+    /**
+     * Gets the extended data.
+     *
+     * @return the extended data as a byte array
+     */
+    public byte[] getExtData() {
+        return extData;
+    }
+
+    @Override
+    public int[] getContainedType() {
+        return new int[] { extendedType };
+    }
+
+    /**
+     * A codec for "extended" data.
+     */
+    public static final class Codec implements DataCodec<ExtendedData> {
+
+        /**
+         * An instance of {@link Codec}.
+         */
+        public static final Codec INSTANCE = new Codec();
+
+        @Override
+        public ExtendedData decode(CodecContext codecContext, byte[] bytes) {
+            if (bytes.length == 0) {
+                return null;
+            }
+
+            int extendedType = bytes[0] & 0xff;
+            byte[] extData = new byte[bytes.length - 1];
+
+            System.arraycopy(bytes, 1, extData, 0, bytes.length - 1);
+
+            return new ExtendedData(extendedType, extData);
+        }
+
+        @Override
+        public byte[] encode(CodecContext codecContext, ExtendedData data) {
+            byte[] bytes = new byte[data.extData.length + 1];
+
+            bytes[0] = (byte) data.extendedType;
+            System.arraycopy(data.extData, 0, bytes, 1, data.extData.length);
+
+            return bytes;
+        }
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/LongExtendedAttribute.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/LongExtendedAttribute.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+
+/**
+ * A long extended attribute in the long extended attribute space. A long extended attribute is encapsulated in one or
+ * more {@link StandardAttribute} attributes containing {@link LongExtendedData} data.
+ *
+ * @param <D> data type
+ */
+public class LongExtendedAttribute<D extends Data> extends Attribute<D> {
+
+    private final int extendedType;
+
+    /**
+     * Constructs a long extended attribute from an attribute type, extended type, and data.
+     *
+     * @param type the attribute type (int in range [0, 255])
+     * @param extendedType the attribute extended type (int in range [0, 255])
+     * @param data the attribute data
+     */
+    public LongExtendedAttribute(int type, int extendedType, D data) {
+        super(new AttributeType(type, extendedType), data);
+
+        if (extendedType < 0 || extendedType > 255) {
+            throw new IllegalArgumentException("Extended type must be in range [0, 255]");
+        }
+
+        this.extendedType = extendedType;
+    }
+
+    /**
+     * Gets the extended attribute type.
+     *
+     * @return the extended attribute type (int in range [0, 255])
+     */
+    public int getExtendedType() {
+        return extendedType;
+    }
+
+    /**
+     * Codec for a {@link LongExtendedAttribute} of a particular data type ({@link D}). An instance of {@link Codec} is
+     * capable of decoding attributes with {@link LongExtendedData} data into extended attributes with a particular data
+     * type.
+     *
+     * @param <D> the attribute data type used in the codec's target attribute
+     */
+    public static class Codec<D extends Data> implements AttributeCodec {
+
+        private final Factory<D> factory;
+
+        private final DataCodec<D> dataCodec;
+
+        /**
+         * Constructs a codec for a {@link LongExtendedAttribute} using the given data codec and attribute instance
+         * factory.
+         *
+         * @param dataCodec the data codec
+         * @param factory the attribute instance factory
+         */
+        public Codec(DataCodec<D> dataCodec, Factory<D> factory) {
+            this.dataCodec = Objects.requireNonNull(dataCodec);
+            this.factory = Objects.requireNonNull(factory);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public int decode(CodecContext codecContext, Deque<Attribute<?>> attributeStack) {
+            Attribute<LongExtendedData> topAttribute = (Attribute<LongExtendedData>) attributeStack.getFirst();
+            AttributeType type = topAttribute.getType();
+            int extendedType = topAttribute.getData().getExtendedType();
+
+            List<Attribute<LongExtendedData>> fragments = new ArrayList<>();
+            boolean expectingMore = false;
+
+            while (attributeStack.size() > 0 && attributeStack.peekFirst().getType().equals(type)) {
+                Attribute<LongExtendedData> nextAttribute = (Attribute<LongExtendedData>) attributeStack.getFirst();
+
+                if (nextAttribute.getData().getExtendedType() != extendedType) {
+                    // The contained type is not the same so we are done getting the fragments for the top attribute
+                    break;
+                }
+
+                fragments.add((Attribute<LongExtendedData>) attributeStack.removeFirst());
+
+                if (!nextAttribute.getData().hasMore()) {
+                    expectingMore = false;
+
+                    break;
+                }
+
+                expectingMore = true;
+            }
+
+            if (expectingMore) {
+                // We were expecting more fragments but didn't get them, so discard all the previous fragments
+                ListIterator<Attribute<LongExtendedData>> iterator = fragments.listIterator(fragments.size());
+
+                while (iterator.hasPrevious()) {
+                    attributeStack.addFirst(iterator.previous());
+                }
+
+                return fragments.size();
+            }
+
+            List<byte[]> extDataFragments = new ArrayList<>();
+            int extDataLength = 0;
+
+            for (Attribute<LongExtendedData> fragment : fragments) {
+                byte[] extDataFragment = fragment.getData().getExtData();
+
+                extDataFragments.add(extDataFragment);
+                extDataLength += extDataFragment.length;
+            }
+
+            byte[] extData = new byte[extDataLength];
+
+            for (int i = 0, position = 0; i < extDataFragments.size(); i++) {
+                byte[] extDataFragment = extDataFragments.get(i);
+                System.arraycopy(extDataFragment, 0, extData, position, extDataFragment.length);
+                position += extDataFragment.length;
+            }
+
+            D data = dataCodec.decode(codecContext, extData);
+
+            if (data == null) {
+                // We couldn't decode the long-extended fragments so place the fragment attributes back on the stack
+                ListIterator<Attribute<LongExtendedData>> iterator = fragments.listIterator(fragments.size());
+
+                while (iterator.hasPrevious()) {
+                    attributeStack.addFirst(iterator.previous());
+                }
+
+                return fragments.size();
+            }
+
+            LongExtendedAttribute<D> longExtendedAttribute = factory.build(type.head(), extendedType, data);
+
+            attributeStack.addFirst(longExtendedAttribute);
+
+            return 0;
+        }
+
+        @Override
+        public void encode(CodecContext codecContext, Deque<Attribute<?>> attributeStack) {
+            @SuppressWarnings("unchecked")
+            LongExtendedAttribute<D> longExtendedAttribute = (LongExtendedAttribute<D>) attributeStack.removeFirst();
+
+            byte[] extData = dataCodec.encode(codecContext, longExtendedAttribute.getData());
+
+            List<Attribute<LongExtendedData>> fragments = new ArrayList<>();
+
+            for (int i = 0; i < extData.length; i += 251) {
+                int extendedType = longExtendedAttribute.extendedType;
+                boolean more = extData.length > i + 251;
+                byte[] extDataFragment = Arrays.copyOfRange(extData, i, Math.min(i + 251, extData.length));
+
+                LongExtendedData longExtendedData = new LongExtendedData(extendedType, extDataFragment, more, false);
+
+                StandardAttribute<LongExtendedData> fragment = new StandardAttribute<>(
+                        longExtendedAttribute.getType().head(), longExtendedData);
+
+                fragments.add(fragment);
+            }
+
+            ListIterator<Attribute<LongExtendedData>> iterator = fragments.listIterator(fragments.size());
+
+            while (iterator.hasPrevious()) {
+                attributeStack.addFirst(iterator.previous());
+            }
+        }
+
+    }
+
+    /**
+     * Attribute factory that returns a concrete instance of {@link LongExtendedAttribute} or a subtype when given a
+     * standard attribute type (integer in range [0, 255]), extended type (integer in range [0, 255]), and attribute
+     * data ({@link D}).
+     *
+     * @param <D> the attribute data type used in the codec's target attribute
+     */
+    @FunctionalInterface
+    public interface Factory<D extends Data> {
+
+        /**
+         * Builds a concrete instance of {@link LongExtendedAttribute}.
+         *
+         * @param type the attribute type (integer in range [0, 255])
+         * @param extendedType the attribute extended type (integer in range [0, 255])
+         * @param data the attribute's data
+         *
+         * @return an instance of {@link LongExtendedAttribute} or its subtypes with the provided type, extended type,
+         * and data
+         */
+        LongExtendedAttribute<D> build(int type, int extendedType, D data);
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/LongExtendedData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/LongExtendedData.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * "long-extended" attribute data type. Long extended data encapsulates an attribute in the long extended attribute
+ * space, allowing the transport of attributes with more than 253 bytes of data.
+ */
+public class LongExtendedData extends ContainerData {
+
+    private final int extendedType;
+
+    private final byte[] extData;
+
+    private final boolean more;
+
+    private final boolean truncation;
+
+    /**
+     * Constructs long extended data.
+     *
+     * @param extendedType the extended type
+     * @param extData the extended data
+     * @param more more boolean flag
+     * @param truncation truncation boolean flag
+     */
+    public LongExtendedData(int extendedType, byte[] extData, boolean more, boolean truncation) {
+        if (extendedType < 0 || extendedType > 255) {
+            throw new IllegalArgumentException("Extended type must be in range [0, 255]");
+        }
+
+        Objects.requireNonNull(extData);
+
+        this.extendedType = extendedType;
+        this.extData = extData;
+        this.more = more;
+        this.truncation = truncation;
+    }
+
+    @Override
+    public int length() {
+        return 2 + extData.length;
+    }
+
+    @Override
+    public int[] getContainedType() {
+        return new int[] { extendedType };
+    }
+
+    /**
+     * Gets the extended type.
+     *
+     * @return the extended type
+     */
+    public int getExtendedType() {
+        return extendedType;
+    }
+
+    /**
+     * Gets the extended data.
+     *
+     * @return the extended data byte array
+     */
+    public byte[] getExtData() {
+        return extData;
+    }
+
+    /**
+     * Gets the more flag.
+     *
+     * @return the more flag
+     */
+    public boolean hasMore() {
+        return more;
+    }
+
+    /**
+     * Gets the truncation flag.
+     *
+     * @return the truncation flag
+     */
+    public boolean isTruncated() {
+        return truncation;
+    }
+
+    /**
+     * A codec for "long-extended" data.
+     */
+    public static final class Codec implements DataCodec<LongExtendedData> {
+
+        /**
+         * An instance of {@link Codec}.
+         */
+        public static final Codec INSTANCE = new Codec();
+
+        @Override
+        public LongExtendedData decode(CodecContext codecContext, byte[] bytes) {
+            if (bytes.length < 2) {
+                return null;
+            }
+
+            int extendedType = bytes[0] & 0xff;
+            byte[] extData = Arrays.copyOfRange(bytes, 2, bytes.length);
+            boolean more = (bytes[1] & 0x80) == 0x80;
+            boolean truncation = (bytes[1] & 0x40) == 0x40;
+
+            return new LongExtendedData(extendedType, extData, more, truncation);
+        }
+
+        @Override
+        public byte[] encode(CodecContext codecContext, LongExtendedData data) {
+            byte[] bytes = new byte[data.extData.length + 2];
+
+            bytes[0] = (byte) data.extendedType;
+            bytes[1] = (byte) ((data.more ? 0x80 : 0x00) | (data.truncation ? 0x40 : 0x00));
+            System.arraycopy(data.extData, 0, bytes, 2, data.extData.length);
+
+            return bytes;
+        }
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute1.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute1.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute1.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.ExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-1 (241) attribute.
+ */
+public final class ExtendedAttribute1 extends StandardAttribute<ExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(241);
+
+    public static final String NAME = "Extended-Attribute-1";
+
+    public ExtendedAttribute1(ExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute2.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute2.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.ExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-2 (242) attribute.
+ */
+public final class ExtendedAttribute2 extends StandardAttribute<ExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(242);
+
+    public static final String NAME = "Extended-Attribute-2";
+
+    public ExtendedAttribute2(ExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute3.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute3.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.ExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-3 (243) attribute.
+ */
+public final class ExtendedAttribute3 extends StandardAttribute<ExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(243);
+
+    public static final String NAME = "Extended-Attribute-3";
+
+    public ExtendedAttribute3(ExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute3.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute4.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute4.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute4.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.ExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-4 (244) attribute.
+ */
+public final class ExtendedAttribute4 extends StandardAttribute<ExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(244);
+
+    public static final String NAME = "Extended-Attribute-4";
+
+    public ExtendedAttribute4(ExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute5.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute5.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.LongExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-5 (245) attribute.
+ */
+public final class ExtendedAttribute5 extends StandardAttribute<LongExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(245);
+
+    public static final String NAME = "Extended-Attribute-5";
+
+    public ExtendedAttribute5(LongExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute6.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/ExtendedAttribute6.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.LongExtendedData;
+import org.aaa4j.radius.core.attribute.StandardAttribute;
+
+/**
+ * Extended-Attribute-6 (246) attribute.
+ */
+public final class ExtendedAttribute6 extends StandardAttribute<LongExtendedData> {
+
+    public static final AttributeType TYPE = new AttributeType(246);
+
+    public static final String NAME = "Extended-Attribute-6";
+
+    public ExtendedAttribute6(LongExtendedData data) {
+        super(TYPE.head(), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/FragStatus.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/FragStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.ExtendedAttribute;
+import org.aaa4j.radius.core.attribute.IntegerData;
+
+/**
+ * Frag-Status (241.1) attribute.
+ */
+public final class FragStatus extends ExtendedAttribute<IntegerData> {
+
+    public static final AttributeType TYPE = new AttributeType(241, 1);
+
+    public static final String NAME = "Frag-Status";
+
+    public FragStatus(IntegerData data) {
+        super(TYPE.head(), TYPE.at(1), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/FragStatus.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/FragStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The AAA4J Authors
+ * Copyright 2020 The AAA4J-RADIUS Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/SamlAssertion.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/attributes/SamlAssertion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute.attributes;
+
+import org.aaa4j.radius.core.attribute.AttributeType;
+import org.aaa4j.radius.core.attribute.LongExtendedAttribute;
+import org.aaa4j.radius.core.attribute.TextData;
+
+/**
+ * Frag-Status (245.1) attribute.
+ */
+public final class SamlAssertion extends LongExtendedAttribute<TextData> {
+
+    public static final AttributeType TYPE = new AttributeType(245, 1);
+
+    public static final String NAME = "SAML-Assertion";
+
+    public SamlAssertion(TextData data) {
+        super(TYPE.head(), TYPE.at(1), data);
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/dictionary/dictionaries/StandardDictionary.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/dictionary/dictionaries/StandardDictionary.java
@@ -23,6 +23,8 @@ import org.aaa4j.radius.core.attribute.ExtendedAttribute;
 import org.aaa4j.radius.core.attribute.ExtendedData;
 import org.aaa4j.radius.core.attribute.IntegerData;
 import org.aaa4j.radius.core.attribute.Ipv4AddrData;
+import org.aaa4j.radius.core.attribute.LongExtendedAttribute;
+import org.aaa4j.radius.core.attribute.LongExtendedData;
 import org.aaa4j.radius.core.attribute.StandardAttribute;
 import org.aaa4j.radius.core.attribute.StringData;
 import org.aaa4j.radius.core.attribute.TextData;
@@ -33,6 +35,8 @@ import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute1;
 import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute2;
 import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute3;
 import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute4;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute5;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute6;
 import org.aaa4j.radius.core.attribute.attributes.FilterId;
 import org.aaa4j.radius.core.attribute.attributes.FragStatus;
 import org.aaa4j.radius.core.attribute.attributes.MessageAuthenticator;
@@ -40,6 +44,7 @@ import org.aaa4j.radius.core.attribute.attributes.NasIdentifier;
 import org.aaa4j.radius.core.attribute.attributes.NasIpAddress;
 import org.aaa4j.radius.core.attribute.attributes.NasPort;
 import org.aaa4j.radius.core.attribute.attributes.ProxyState;
+import org.aaa4j.radius.core.attribute.attributes.SamlAssertion;
 import org.aaa4j.radius.core.attribute.attributes.State;
 import org.aaa4j.radius.core.attribute.attributes.UserName;
 import org.aaa4j.radius.core.attribute.attributes.UserPassword;
@@ -248,6 +253,33 @@ public final class StandardDictionary implements Dictionary {
                         ExtendedData.class,
                         new StandardAttribute.Codec<>(
                                 ExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute4(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute5.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute5.TYPE,
+                        ExtendedAttribute5.NAME,
+                        ExtendedAttribute5.class,
+                        LongExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                LongExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute5(data))));
+
+        attributeDefinitionsMap.put(SamlAssertion.TYPE,
+                new AttributeDefinition(
+                        SamlAssertion.TYPE,
+                        SamlAssertion.NAME,
+                        SamlAssertion.class,
+                        TextData.class,
+                        new LongExtendedAttribute.Codec<>(
+                                TextData.Codec.INSTANCE, (type, extendedType, data) -> new SamlAssertion(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute6.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute6.TYPE,
+                        ExtendedAttribute6.NAME,
+                        ExtendedAttribute6.class,
+                        LongExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                LongExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute6(data))));
     }
 
     @Override

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/dictionary/dictionaries/StandardDictionary.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/dictionary/dictionaries/StandardDictionary.java
@@ -19,6 +19,8 @@ package org.aaa4j.radius.core.dictionary.dictionaries;
 import org.aaa4j.radius.core.attribute.AttributeType;
 import org.aaa4j.radius.core.attribute.ConcatAttribute;
 import org.aaa4j.radius.core.attribute.ConcatData;
+import org.aaa4j.radius.core.attribute.ExtendedAttribute;
+import org.aaa4j.radius.core.attribute.ExtendedData;
 import org.aaa4j.radius.core.attribute.IntegerData;
 import org.aaa4j.radius.core.attribute.Ipv4AddrData;
 import org.aaa4j.radius.core.attribute.StandardAttribute;
@@ -27,7 +29,12 @@ import org.aaa4j.radius.core.attribute.TextData;
 import org.aaa4j.radius.core.attribute.UserPasswordDataCodec;
 import org.aaa4j.radius.core.attribute.VsaData;
 import org.aaa4j.radius.core.attribute.attributes.EapMessage;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute1;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute2;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute3;
+import org.aaa4j.radius.core.attribute.attributes.ExtendedAttribute4;
 import org.aaa4j.radius.core.attribute.attributes.FilterId;
+import org.aaa4j.radius.core.attribute.attributes.FragStatus;
 import org.aaa4j.radius.core.attribute.attributes.MessageAuthenticator;
 import org.aaa4j.radius.core.attribute.attributes.NasIdentifier;
 import org.aaa4j.radius.core.attribute.attributes.NasIpAddress;
@@ -196,6 +203,51 @@ public final class StandardDictionary implements Dictionary {
                         StringData.class,
                         new StandardAttribute.Codec<>(
                                 StringData.Codec.INSTANCE, (type, data) -> new MessageAuthenticator(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute1.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute1.TYPE,
+                        ExtendedAttribute1.NAME,
+                        ExtendedAttribute1.class,
+                        ExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                ExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute1(data))));
+
+        attributeDefinitionsMap.put(FragStatus.TYPE,
+                new AttributeDefinition(
+                        FragStatus.TYPE,
+                        FragStatus.NAME,
+                        FragStatus.class,
+                        IntegerData.class,
+                        new ExtendedAttribute.Codec<>(
+                                IntegerData.Codec.INSTANCE, (type, extendedType, data) -> new FragStatus(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute2.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute2.TYPE,
+                        ExtendedAttribute2.NAME,
+                        ExtendedAttribute2.class,
+                        ExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                ExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute2(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute3.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute3.TYPE,
+                        ExtendedAttribute3.NAME,
+                        ExtendedAttribute3.class,
+                        ExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                ExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute3(data))));
+
+        attributeDefinitionsMap.put(ExtendedAttribute4.TYPE,
+                new AttributeDefinition(
+                        ExtendedAttribute4.TYPE,
+                        ExtendedAttribute4.NAME,
+                        ExtendedAttribute4.class,
+                        ExtendedData.class,
+                        new StandardAttribute.Codec<>(
+                                ExtendedData.Codec.INSTANCE, (type, data) -> new ExtendedAttribute4(data))));
     }
 
     @Override

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/packet/PacketCodec.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/packet/PacketCodec.java
@@ -210,7 +210,7 @@ public final class PacketCodec {
 
         bytes[0] = (byte) (response.getCode() & 0xff);
         bytes[1] = (byte) (requestId & 0xff);
-        bytes[2] = (byte) ((byte) (packetLength & 0xff00) >>> 8);
+        bytes[2] = (byte) ((packetLength & 0xff00) >>> 8);
         bytes[3] = (byte) (packetLength & 0xff);
 
         int position = 20;

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/ExtendedAttributeTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/ExtendedAttributeTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.aaa4j.radius.core.attribute.attributes.FragStatus;
+import org.aaa4j.radius.core.attribute.attributes.NasIdentifier;
+import org.aaa4j.radius.core.dictionary.dictionaries.StandardDictionary;
+import org.aaa4j.radius.core.packet.Packet;
+import org.aaa4j.radius.core.packet.PacketCodec;
+import org.aaa4j.radius.core.packet.PacketCodecException;
+import org.aaa4j.radius.core.packet.PacketIdGenerator;
+import org.aaa4j.radius.core.util.RandomProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ExtendedAttribute")
+class ExtendedAttributeTest {
+
+    private PacketIdGenerator mockedPacketIdGenerator;
+
+    private RandomProvider mockedRandomProvider;
+
+    private PacketCodec packetCodec;
+
+    @BeforeEach
+    void setUp() {
+        mockedPacketIdGenerator = mock(PacketIdGenerator.class);
+        mockedRandomProvider = mock(RandomProvider.class);
+
+        packetCodec = new PacketCodec(new StandardDictionary(), mockedRandomProvider, mockedPacketIdGenerator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(mockedPacketIdGenerator);
+        reset(mockedRandomProvider);
+    }
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new ExtendedAttribute<>(241, 1, null);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedAttribute<>(-1, 1, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedAttribute<>(256, 1, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedAttribute<>(241, -1, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedAttribute<>(241, 256, new IntegerData(256));
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        ExtendedAttribute<IntegerData> extendedAttribute = new ExtendedAttribute<>(241, 242, new IntegerData(256));
+
+        assertEquals(new AttributeType(241, 242), extendedAttribute.getType());
+        assertEquals(242, extendedAttribute.getExtendedType());
+        assertEquals(256, extendedAttribute.getData().getValue());
+    }
+
+    @Test
+    @DisplayName("Extended attribute in a request packet is encoded successfully")
+    void encodeRequestExtendedAttribute() throws PacketCodecException {
+        when(mockedPacketIdGenerator.nextId()).thenReturn(42);
+
+        Packet requestPacket = new Packet(1, List.of(
+                new NasIdentifier(new TextData("00a1b2c3d4")),
+                new FragStatus(new IntegerData(256))));
+
+        byte[] actual = packetCodec.encodeRequest(requestPacket, "abc123".getBytes(US_ASCII),
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        assertEquals("012a0027f58c0714b19ce47b2e4976e62dd7d6fc200c30306131623263336434f1070100000100",
+                toHex(actual));
+    }
+
+    @Test
+    @DisplayName("Extended attribute in a request packet is decoded successfully")
+    void decodeRequestExtendedAttribute() throws PacketCodecException {
+        byte[] encoded = fromHex("012a0027f58c0714b19ce47b2e4976e62dd7d6fc200c30306131623263336434f1070100000100");
+
+        Packet requestPacket = packetCodec.decodeRequest(encoded, "abc123".getBytes(US_ASCII));
+
+        assertThat(requestPacket.getAttributes().get(0), instanceOf(NasIdentifier.class));
+        NasIdentifier nasIdentifier = (NasIdentifier) requestPacket.getAttributes().get(0);
+        assertEquals("00a1b2c3d4", nasIdentifier.getData().getValue());
+
+        assertThat(requestPacket.getAttributes().get(1), instanceOf(FragStatus.class));
+        FragStatus fragStatus = (FragStatus) requestPacket.getAttributes().get(1);
+        assertEquals(256, fragStatus.getData().getValue());
+    }
+
+    @Test
+    @DisplayName("Extended attribute in a response packet is encoded successfully")
+    void encodeResponseExtendedAttribute() throws PacketCodecException {
+        Packet requestPacket = new Packet(2, List.of(new FragStatus(new IntegerData(1024))));
+
+        byte[] actual = packetCodec.encodeResponse(requestPacket, "abc123".getBytes(US_ASCII), 42,
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        assertEquals("022a001b9b4299a3622bd66afc97eb3a1153d018f1070100000400",
+                toHex(actual));
+    }
+
+    @Test
+    @DisplayName("Extended attribute in a response packet is decoded successfully")
+    void decodeResponseExtendedAttribute() throws PacketCodecException {
+        byte[] encoded = fromHex("022a001b9b4299a3622bd66afc97eb3a1153d018f1070100000400");
+
+        Packet requestPacket = packetCodec.decodeResponse(encoded, "abc123".getBytes(US_ASCII),
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        assertThat(requestPacket.getAttributes().get(0), instanceOf(FragStatus.class));
+        FragStatus fragStatus = (FragStatus) requestPacket.getAttributes().get(0);
+        assertEquals(1024, fragStatus.getData().getValue());
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/ExtendedDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/ExtendedDataTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("ExtendedData")
+class ExtendedDataTest {
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new ExtendedData(241, null);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedData(-1, new byte[] { 0x00, 0x01 });
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ExtendedData(256, new byte[] { 0x00, 0x01 });
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        ExtendedData extendedData = new ExtendedData(3, fromHex("0280de81"));
+
+        assertEquals(5, extendedData.length());
+        assertEquals(3, extendedData.getExtendedType());
+        assertArrayEquals(new int[] { 3 }, extendedData.getContainedType());
+        assertEquals("0280de81", toHex(extendedData.getExtData()));
+    }
+
+    @Test
+    @DisplayName("extended data is decoded successfully")
+    void testDecode() {
+        byte[] encoded = fromHex("030280de81");
+
+        ExtendedData extendedData = ExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+        assertNotNull(extendedData);
+        assertEquals(5, extendedData.length());
+        assertEquals(3, extendedData.getExtendedType());
+        assertArrayEquals(new int[] { 3 }, extendedData.getContainedType());
+        assertEquals("0280de81", toHex(extendedData.getExtData()));
+    }
+
+    @Test
+    @DisplayName("extended data is encoded successfully")
+    void testEncode() {
+        ExtendedData extendedData = new ExtendedData(3, fromHex("0280de81"));
+        byte[] encoded = ExtendedData.Codec.INSTANCE.encode(null, extendedData);
+
+        assertEquals("030280de81", toHex(encoded));
+    }
+
+    @Test
+    @DisplayName("Invalid extended data is decoded into null")
+    void testDecodeInvalid() {
+        // Too few bytes
+        byte[] encoded = fromHex("");
+        ExtendedData extendedData = ExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+        assertNull(extendedData);
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedAttributeTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedAttributeTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.aaa4j.radius.core.attribute.attributes.NasIdentifier;
+import org.aaa4j.radius.core.attribute.attributes.SamlAssertion;
+import org.aaa4j.radius.core.dictionary.dictionaries.StandardDictionary;
+import org.aaa4j.radius.core.packet.Packet;
+import org.aaa4j.radius.core.packet.PacketCodec;
+import org.aaa4j.radius.core.packet.PacketCodecException;
+import org.aaa4j.radius.core.packet.PacketIdGenerator;
+import org.aaa4j.radius.core.util.RandomProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+@DisplayName("LongExtendedAttribute")
+class LongExtendedAttributeTest {
+
+    private PacketIdGenerator mockedPacketIdGenerator;
+
+    private RandomProvider mockedRandomProvider;
+
+    private PacketCodec packetCodec;
+
+    @BeforeEach
+    void setUp() {
+        mockedPacketIdGenerator = mock(PacketIdGenerator.class);
+        mockedRandomProvider = mock(RandomProvider.class);
+
+        packetCodec = new PacketCodec(new StandardDictionary(), mockedRandomProvider, mockedPacketIdGenerator);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(mockedPacketIdGenerator);
+        reset(mockedRandomProvider);
+    }
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new LongExtendedAttribute<>(245, 241, null);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedAttribute<>(-1, 241, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedAttribute<>(256, 241, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedAttribute<>(241, -1, new IntegerData(256));
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedAttribute<>(241, 256, new IntegerData(256));
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        LongExtendedAttribute<IntegerData> longExtendedAttribute = new LongExtendedAttribute<IntegerData>(245, 241,
+                new IntegerData(256));
+
+        assertEquals(new AttributeType(245, 241), longExtendedAttribute.getType());
+        assertEquals(241, longExtendedAttribute.getExtendedType());
+        assertEquals(256, longExtendedAttribute.getData().getValue());
+    }
+
+    @Test
+    @DisplayName("Long extended attribute in a request packet is encoded successfully")
+    void encodeRequestLongExtendedAttribute() throws PacketCodecException {
+        when(mockedPacketIdGenerator.nextId()).thenReturn(42);
+
+        String combined = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "ccc";
+
+        Packet requestPacket = new Packet(1, List.of(
+                new NasIdentifier(new TextData("00a1b2c3d4")),
+                new SamlAssertion(new TextData(combined))));
+
+        byte[] actual = packetCodec.encodeRequest(requestPacket, "abc123".getBytes(US_ASCII),
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        String expected = "012a0225f58c0714b19ce47b2e4976e62dd7d6fc200c30306131623263336434" +
+                "f5ff018061616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "61616161616161616161616161616161616161616161616161616161616161f5" +
+                "ff01806262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "626262626262626262626262626262626262626262626262626262626262f507" +
+                "0100636363";
+
+        assertEquals(expected, toHex(actual));
+    }
+
+    @Test
+    @DisplayName("Long extended attribute in a request packet is decoded successfully")
+    void decodeRequestLongExtendedAttribute() throws PacketCodecException {
+        byte[] encoded = fromHex("012a0225f58c0714b19ce47b2e4976e62dd7d6fc200c30306131623263336434" +
+                "f5ff018061616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "61616161616161616161616161616161616161616161616161616161616161f5" +
+                "ff01806262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "626262626262626262626262626262626262626262626262626262626262f507" +
+                "0100636363");
+
+        Packet requestPacket = packetCodec.decodeRequest(encoded, "abc123".getBytes(US_ASCII));
+
+        assertThat(requestPacket.getAttributes().get(0), instanceOf(NasIdentifier.class));
+        NasIdentifier nasIdentifier = (NasIdentifier) requestPacket.getAttributes().get(0);
+        assertEquals("00a1b2c3d4", nasIdentifier.getData().getValue());
+
+        String combined = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "ccc";
+
+        assertThat(requestPacket.getAttributes().get(1), instanceOf(SamlAssertion.class));
+        SamlAssertion samlAssertion = (SamlAssertion) requestPacket.getAttributes().get(1);
+        assertEquals(combined, samlAssertion.getData().getValue());
+    }
+
+    @Test
+    @DisplayName("Long extended attribute in a response packet is encoded successfully")
+    void encodeResponseLongExtendedAttribute() throws PacketCodecException {
+        String combined = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "ccc";
+
+        Packet responsePacket = new Packet(2, List.of(
+                new SamlAssertion(new TextData(combined))));
+
+        byte[] actual = packetCodec.encodeResponse(responsePacket, "abc123".getBytes(US_ASCII), 42,
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        String expected = "022a021965a83c683eb8a5ed13201c838d31c7a2f5ff01806161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "61616161616161616161616161616161616161f5ff0180626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "626262626262626262626262626262626262f5070100636363";
+
+        assertEquals(expected, toHex(actual));
+    }
+
+    @Test
+    @DisplayName("Long extended attribute in a response packet is decoded successfully")
+    void decodeResponseLongExtendedAttribute() throws PacketCodecException {
+        String combined = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+                "ccc";
+
+        byte[] encoded = fromHex("022a021965a83c683eb8a5ed13201c838d31c7a2f5ff01806161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "6161616161616161616161616161616161616161616161616161616161616161" +
+                "61616161616161616161616161616161616161f5ff0180626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "6262626262626262626262626262626262626262626262626262626262626262" +
+                "626262626262626262626262626262626262f5070100636363");
+
+        Packet requestPacket = packetCodec.decodeResponse(encoded, "abc123".getBytes(US_ASCII),
+                fromHex("f58c0714b19ce47b2e4976e62dd7d6fc"));
+
+        assertThat(requestPacket.getAttributes().get(0), instanceOf(SamlAssertion.class));
+        SamlAssertion samlAssertion = (SamlAssertion) requestPacket.getAttributes().get(0);
+        assertEquals(combined, samlAssertion.getData().getValue());
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedDataTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("LongExtendedData")
+class LongExtendedDataTest {
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new LongExtendedData(241, null, false, false);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedData(-1, new byte[] { 0x00, 0x01 }, false, false);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongExtendedData(256, new byte[] { 0x00, 0x01 }, false, false);
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        LongExtendedData longExtendedData = new LongExtendedData(10, fromHex("a8f000874daa9b"), false, false);
+
+        assertEquals(9, longExtendedData.length());
+        assertEquals(10, longExtendedData.getExtendedType());
+        assertArrayEquals(new int[] { 10 }, longExtendedData.getContainedType());
+        assertEquals("a8f000874daa9b", toHex(longExtendedData.getExtData()));
+        assertFalse(longExtendedData.hasMore());
+        assertFalse(longExtendedData.isTruncated());
+    }
+
+    @Test
+    @DisplayName("long-extended data is decoded successfully")
+    void testDecode() {
+        {
+            byte[] encoded = fromHex("0ac0a8f000874daa9b");
+
+            LongExtendedData longExtendedData = LongExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+            assertNotNull(longExtendedData);
+            assertEquals(9, longExtendedData.length());
+            assertEquals(10, longExtendedData.getExtendedType());
+            assertArrayEquals(new int[]{10}, longExtendedData.getContainedType());
+            assertEquals("a8f000874daa9b", toHex(longExtendedData.getExtData()));
+            assertTrue(longExtendedData.hasMore());
+            assertTrue(longExtendedData.isTruncated());
+        }
+        {
+            byte[] encoded = fromHex("0b009c0e122fe2120c");
+
+            LongExtendedData longExtendedData = LongExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+            assertNotNull(longExtendedData);
+            assertEquals(9, longExtendedData.length());
+            assertEquals(11, longExtendedData.getExtendedType());
+            assertArrayEquals(new int[]{11}, longExtendedData.getContainedType());
+            assertEquals("9c0e122fe2120c", toHex(longExtendedData.getExtData()));
+            assertFalse(longExtendedData.hasMore());
+            assertFalse(longExtendedData.isTruncated());
+        }
+        {
+            byte[] encoded = fromHex("0d80582dd2b7e9da2332731851d42ee54e7cea185f168f7d2fffc47361e2869b" +
+                    "a65310e2db3631c6e815561cc2967e4252d84d5d1226afb79c71ac523832ee09" +
+                    "d50a13490d255d3ae641b97678d331c62236e16c90ec2cdd0193c8ac59ffd0c0" +
+                    "82f4c9875586316bf78166e640a0f1bd538ff6694159f3782d417ca471512f3d" +
+                    "c41528f7e6d3b6c38d64c92ddecea356ee7f597bcffa7656129eb4a859084837" +
+                    "e8f5f5bd3cdeda8700e24960a3da9aed3e4ab5e930b4f83401dee5a0041235ad" +
+                    "4c17e7e6c8bf2bb3fbdab2b7a89c664cfbd980c0ea0669914516bd90a63817be" +
+                    "90ee0dcfce12d8d4831e470b621ecf3a15b3423383d6cc7c791c96de7a943a");
+
+            LongExtendedData longExtendedData = LongExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+            assertNotNull(longExtendedData);
+            assertEquals(255, longExtendedData.length());
+            assertEquals(13, longExtendedData.getExtendedType());
+            assertArrayEquals(new int[]{13}, longExtendedData.getContainedType());
+
+            byte[] expectedExtData = fromHex("582dd2b7e9da2332731851d42ee54e7cea185f168f7d2fffc47361e2869ba653" +
+                    "10e2db3631c6e815561cc2967e4252d84d5d1226afb79c71ac523832ee09d50a" +
+                    "13490d255d3ae641b97678d331c62236e16c90ec2cdd0193c8ac59ffd0c082f4" +
+                    "c9875586316bf78166e640a0f1bd538ff6694159f3782d417ca471512f3dc415" +
+                    "28f7e6d3b6c38d64c92ddecea356ee7f597bcffa7656129eb4a859084837e8f5" +
+                    "f5bd3cdeda8700e24960a3da9aed3e4ab5e930b4f83401dee5a0041235ad4c17" +
+                    "e7e6c8bf2bb3fbdab2b7a89c664cfbd980c0ea0669914516bd90a63817be90ee" +
+                    "0dcfce12d8d4831e470b621ecf3a15b3423383d6cc7c791c96de7a943a");
+
+            assertArrayEquals(expectedExtData, longExtendedData.getExtData());
+            assertTrue(longExtendedData.hasMore());
+            assertFalse(longExtendedData.isTruncated());
+        }
+    }
+
+    @Test
+    @DisplayName("long-extended data is encoded successfully")
+    void testEncode() {
+        {
+            LongExtendedData longExtendedData = new LongExtendedData(10, fromHex("a8f000874daa9b"), true, true);
+            byte[] encoded = LongExtendedData.Codec.INSTANCE.encode(null, longExtendedData);
+
+            assertEquals("0ac0a8f000874daa9b", toHex(encoded));
+        }
+        {
+            LongExtendedData longExtendedData = new LongExtendedData(11, fromHex("9c0e122fe2120c"), false, false);
+            byte[] encoded = LongExtendedData.Codec.INSTANCE.encode(null, longExtendedData);
+
+            assertEquals("0b009c0e122fe2120c", toHex(encoded));
+        }
+        {
+            byte[] extData = fromHex("582dd2b7e9da2332731851d42ee54e7cea185f168f7d2fffc47361e2869ba653" +
+                    "10e2db3631c6e815561cc2967e4252d84d5d1226afb79c71ac523832ee09d50a" +
+                    "13490d255d3ae641b97678d331c62236e16c90ec2cdd0193c8ac59ffd0c082f4" +
+                    "c9875586316bf78166e640a0f1bd538ff6694159f3782d417ca471512f3dc415" +
+                    "28f7e6d3b6c38d64c92ddecea356ee7f597bcffa7656129eb4a859084837e8f5" +
+                    "f5bd3cdeda8700e24960a3da9aed3e4ab5e930b4f83401dee5a0041235ad4c17" +
+                    "e7e6c8bf2bb3fbdab2b7a89c664cfbd980c0ea0669914516bd90a63817be90ee" +
+                    "0dcfce12d8d4831e470b621ecf3a15b3423383d6cc7c791c96de7a943a");
+
+            LongExtendedData longExtendedData = new LongExtendedData(13, extData, true, false);
+            byte[] encoded = LongExtendedData.Codec.INSTANCE.encode(null, longExtendedData);
+
+            String expected = "0d80582dd2b7e9da2332731851d42ee54e7cea185f168f7d2fffc47361e2869b" +
+                    "a65310e2db3631c6e815561cc2967e4252d84d5d1226afb79c71ac523832ee09" +
+                    "d50a13490d255d3ae641b97678d331c62236e16c90ec2cdd0193c8ac59ffd0c0" +
+                    "82f4c9875586316bf78166e640a0f1bd538ff6694159f3782d417ca471512f3d" +
+                    "c41528f7e6d3b6c38d64c92ddecea356ee7f597bcffa7656129eb4a859084837" +
+                    "e8f5f5bd3cdeda8700e24960a3da9aed3e4ab5e930b4f83401dee5a0041235ad" +
+                    "4c17e7e6c8bf2bb3fbdab2b7a89c664cfbd980c0ea0669914516bd90a63817be" +
+                    "90ee0dcfce12d8d4831e470b621ecf3a15b3423383d6cc7c791c96de7a943a";
+
+            assertEquals(expected, toHex(encoded));
+        }
+    }
+
+    @Test
+    @DisplayName("Invalid long-extended data is decoded into null")
+    void testDecodeInvalid() {
+        // Too few bytes
+        byte[] encoded = fromHex("");
+        LongExtendedData longExtendedData = LongExtendedData.Codec.INSTANCE.decode(null, encoded);
+
+        assertNull(longExtendedData);
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/LongExtendedDataTest.java
@@ -72,7 +72,7 @@ class LongExtendedDataTest {
             assertNotNull(longExtendedData);
             assertEquals(9, longExtendedData.length());
             assertEquals(10, longExtendedData.getExtendedType());
-            assertArrayEquals(new int[]{10}, longExtendedData.getContainedType());
+            assertArrayEquals(new int[] { 10 }, longExtendedData.getContainedType());
             assertEquals("a8f000874daa9b", toHex(longExtendedData.getExtData()));
             assertTrue(longExtendedData.hasMore());
             assertTrue(longExtendedData.isTruncated());
@@ -85,7 +85,7 @@ class LongExtendedDataTest {
             assertNotNull(longExtendedData);
             assertEquals(9, longExtendedData.length());
             assertEquals(11, longExtendedData.getExtendedType());
-            assertArrayEquals(new int[]{11}, longExtendedData.getContainedType());
+            assertArrayEquals(new int[] { 11 }, longExtendedData.getContainedType());
             assertEquals("9c0e122fe2120c", toHex(longExtendedData.getExtData()));
             assertFalse(longExtendedData.hasMore());
             assertFalse(longExtendedData.isTruncated());
@@ -105,7 +105,7 @@ class LongExtendedDataTest {
             assertNotNull(longExtendedData);
             assertEquals(255, longExtendedData.length());
             assertEquals(13, longExtendedData.getExtendedType());
-            assertArrayEquals(new int[]{13}, longExtendedData.getContainedType());
+            assertArrayEquals(new int[] { 13 }, longExtendedData.getContainedType());
 
             byte[] expectedExtData = fromHex("582dd2b7e9da2332731851d42ee54e7cea185f168f7d2fffc47361e2869ba653" +
                     "10e2db3631c6e815561cc2967e4252d84d5d1226afb79c71ac523832ee09d50a" +


### PR DESCRIPTION
Added `ExtendedData`, `ExtendedAttribute`, `LongExtendedData`, `LongExtendedAttribute` and tests to support the `long` and `long-extended` RADIUS attribute formats. Also updated `StandardDictionary` with new container attributes `ExtendedAttribute1`, `ExtendedAttribute2`, `ExtendedAttribute3`, `ExtendedAttribute4`, `ExtendedAttribute5`, `ExtendedAttribute6`.