### PR TITLE
Added tagged types

### DIFF
--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/OptionalTaggedStringData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/OptionalTaggedStringData.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A "string" attribute data type containing an optional 1-byte tag. The string (of octets) data is mapped to a byte
+ * array.
+ */
+public class OptionalTaggedStringData extends Data {
+
+    private final byte[] value;
+
+    private final Integer tag;
+
+    /**
+     * Constructs tagged string data from a given byte array and tag.
+     *
+     * @param value the byte array
+     * @param tag the tag (int in range [0, 31])
+     */
+    public OptionalTaggedStringData(byte[] value, int tag) {
+        if (tag < 0 || tag > 31) {
+            throw new IllegalArgumentException("Tag must be in range [0, 31]");
+        }
+
+        this.tag = tag;
+        this.value = Objects.requireNonNull(value);
+    }
+
+    /**
+     * Constructs tagged string data from a given byte array. No tag is included in the data with this constructor.
+     *
+     * @param value the byte array
+     */
+    public OptionalTaggedStringData(byte[] value) {
+        this.tag = null;
+        this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    public int length() {
+        return tag == null ? value.length : 1 + value.length;
+    }
+
+    /**
+     * Gets the octet string value as a byte array.
+     *
+     * @return the string value as a byte array
+     */
+    public byte[] getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the optional tag.
+     *
+     * @return optional tag (Optional with Integer in range [0, 31])
+     */
+    public Optional<Integer> getTag() {
+        return Optional.ofNullable(tag);
+    }
+
+    /**
+     * A codec for optional tagged "string" data.
+     */
+    public static class Codec implements DataCodec<OptionalTaggedStringData> {
+
+        /**
+         * An instance of {@link Codec}.
+         */
+        public static final Codec INSTANCE = new Codec();
+
+        @Override
+        public OptionalTaggedStringData decode(CodecContext codecContext, AttributeType parentAttributeType,
+                byte[] bytes) {
+            if (bytes.length < 1) {
+                return new OptionalTaggedStringData(new byte[] {});
+            }
+
+            int tag = bytes[0] & 0xff;
+
+            if (tag > 31) {
+                return new OptionalTaggedStringData(bytes);
+            }
+
+            return new OptionalTaggedStringData(Arrays.copyOfRange(bytes, 1, bytes.length), tag);
+        }
+
+        @Override
+        public byte[] encode(CodecContext codecContext, AttributeType parentAttributeType, Data data) {
+            OptionalTaggedStringData optionalTaggedStringData = (OptionalTaggedStringData) data;
+
+            if (optionalTaggedStringData.tag != null) {
+                byte[] bytes = new byte[1 + optionalTaggedStringData.value.length];
+
+                bytes[0] = optionalTaggedStringData.tag.byteValue();
+                System.arraycopy(optionalTaggedStringData.value, 0, bytes, 1, optionalTaggedStringData.value.length);
+
+                return bytes;
+            }
+
+            return optionalTaggedStringData.value;
+        }
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/TaggedIntegerData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/TaggedIntegerData.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+/**
+ * An "integer" attribute data type containing a 1-byte tag. "integer" data is a 32-bit unsigned integer but is
+ * represented as a signed Java <code>int</code>.
+ */
+public final class TaggedIntegerData extends Data {
+
+    private final int value;
+
+    private final int tag;
+
+    /**
+     * Constructs tagged integer data from a given integer value and tag.
+     *
+     * @param value the byte array
+     * @param tag the tag (int in range [0, 31])
+     */
+    public TaggedIntegerData(int value, int tag) {
+        if (tag < 0 || tag > 31) {
+            throw new IllegalArgumentException("Tag must be in range [0, 31]");
+        }
+
+        if (value < 0 || value > 16777215) {
+            throw new IllegalArgumentException("Value must be in range [0, 16777215]");
+        }
+
+        this.tag = tag;
+        this.value = value;
+    }
+
+    @Override
+    public int length() {
+        return 4;
+    }
+
+    /**
+     * Gets the integer value.
+     *
+     * @return the integer as a signed Java int
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the tag.
+     *
+     * @return the tag (int in range [0, 31])
+     */
+    public int getTag() {
+        return tag;
+    }
+
+    /**
+     * A codec for tagged "integer" data.
+     */
+    public static final class Codec implements DataCodec<TaggedIntegerData> {
+
+        /**
+         * An instance of {@link Codec}.
+         */
+        public static final Codec INSTANCE = new Codec();
+
+        @Override
+        public TaggedIntegerData decode(CodecContext codecContext, AttributeType parentAttributeType, byte[] bytes) {
+            if (bytes.length != 4) {
+                return null;
+            }
+
+            int tag = bytes[0] & 0xff;
+
+            if (tag > 31) {
+                return null;
+            }
+
+            int value = (bytes[1] & 0xff) << 16
+                    | (bytes[2] & 0xff) << 8
+                    | bytes[3] & 0xff;
+
+            return new TaggedIntegerData(value, tag);
+        }
+
+        @Override
+        public byte[] encode(CodecContext codecContext, AttributeType parentAttributeType, Data data) {
+            TaggedIntegerData taggedIntegerData = (TaggedIntegerData) data;
+
+            byte[] bytes = new byte[4];
+
+            bytes[0] = (byte) taggedIntegerData.tag;
+            bytes[1] = (byte) ((taggedIntegerData.value & 0x00ff0000) >>> 16);
+            bytes[2] = (byte) ((taggedIntegerData.value & 0x0000ff00) >>> 8);
+            bytes[3] = (byte) (taggedIntegerData.value & 0x000000ff);
+
+            return bytes;
+        }
+
+    }
+
+}

--- a/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/TaggedStringData.java
+++ b/aaa4j-radius-core/src/main/java/org/aaa4j/radius/core/attribute/TaggedStringData.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A "string" attribute data type containing a 1-byte tag. The string (of octets) data is mapped to a byte array.
+ */
+public class TaggedStringData extends Data {
+
+    private final byte[] value;
+
+    private final int tag;
+
+    /**
+     * Constructs tagged string data from a given byte array and tag.
+     *
+     * @param value the byte array
+     * @param tag the tag (int in range [0, 31])
+     */
+    public TaggedStringData(byte[] value, int tag) {
+        if (tag < 0 || tag > 31) {
+            throw new IllegalArgumentException("Tag must be in range [0, 31]");
+        }
+
+        this.tag = tag;
+        this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    public int length() {
+        return 1 + value.length;
+    }
+
+    /**
+     * Gets the octet string value as a byte array.
+     *
+     * @return the string value as a byte array
+     */
+    public byte[] getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the tag.
+     *
+     * @return the tag (int in range [0, 31])
+     */
+    public int getTag() {
+        return tag;
+    }
+
+    /**
+     * A codec for tagged "string" data.
+     */
+    public static class Codec implements DataCodec<TaggedStringData> {
+
+        /**
+         * An instance of {@link Codec}.
+         */
+        public static final Codec INSTANCE = new Codec();
+
+        @Override
+        public TaggedStringData decode(CodecContext codecContext, AttributeType parentAttributeType, byte[] bytes) {
+            if (bytes.length < 1) {
+                return null;
+            }
+
+            int tag = bytes[0] & 0xff;
+
+            if (tag > 31) {
+                // If the tag field is unused, the tag must be 0x00
+                return null;
+            }
+
+            return new TaggedStringData(Arrays.copyOfRange(bytes, 1, bytes.length), tag);
+        }
+
+        @Override
+        public byte[] encode(CodecContext codecContext, AttributeType parentAttributeType, Data data) {
+            TaggedStringData taggedStringData = (TaggedStringData) data;
+
+            byte[] bytes = new byte[1 + taggedStringData.value.length];
+
+            bytes[0] = (byte) taggedStringData.tag;
+
+            System.arraycopy(taggedStringData.value, 0, bytes, 1, taggedStringData.value.length);
+
+            return bytes;
+        }
+
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/OptionalTaggedStringDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/OptionalTaggedStringDataTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("OptionalTaggedStringData")
+class OptionalTaggedStringDataTest {
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new OptionalTaggedStringData(null, 2);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new OptionalTaggedStringData(new byte[3], 32);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new OptionalTaggedStringData(new byte[3], -1);
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        OptionalTaggedStringData optionalTaggedStringData = new OptionalTaggedStringData(fromHex("8af9bc"), 31);
+
+        assertEquals(4, optionalTaggedStringData.length());
+        assertEquals("8af9bc", toHex(optionalTaggedStringData.getValue()));
+        assertTrue(optionalTaggedStringData.getTag().isPresent());
+        assertEquals(31, optionalTaggedStringData.getTag().get());
+    }
+
+    @Test
+    @DisplayName("Optional tagged string data is decoded successfully")
+    void testDecode() {
+        {
+            // With tag
+            byte[] encoded = fromHex("028af9bc");
+
+            OptionalTaggedStringData optionalTaggedStringData = OptionalTaggedStringData.Codec.INSTANCE.decode(null,
+                    null, encoded);
+
+            assertNotNull(optionalTaggedStringData);
+            assertEquals("8af9bc", toHex(optionalTaggedStringData.getValue()));
+            assertTrue(optionalTaggedStringData.getTag().isPresent());
+            assertEquals(2, optionalTaggedStringData.getTag().get());
+        }
+        {
+            // Without tag
+            byte[] encoded = fromHex("8af9bc");
+
+            OptionalTaggedStringData optionalTaggedStringData = OptionalTaggedStringData.Codec.INSTANCE.decode(null,
+                    null, encoded);
+
+            assertNotNull(optionalTaggedStringData);
+            assertEquals("8af9bc", toHex(optionalTaggedStringData.getValue()));
+            assertFalse(optionalTaggedStringData.getTag().isPresent());
+        }
+    }
+
+    @Test
+    @DisplayName("Optional tagged string data is encoded successfully")
+    void testEncode() {
+        {
+            // With tag
+            OptionalTaggedStringData optionalTaggedStringData = new OptionalTaggedStringData(fromHex("8af9bc"), 2);
+            byte[] encoded = OptionalTaggedStringData.Codec.INSTANCE.encode(null, null, optionalTaggedStringData);
+
+            assertEquals("028af9bc", toHex(encoded));
+        }
+        {
+            // Without tag
+            OptionalTaggedStringData optionalTaggedStringData = new OptionalTaggedStringData(fromHex("8af9bc"));
+            byte[] encoded = OptionalTaggedStringData.Codec.INSTANCE.encode(null, null, optionalTaggedStringData);
+
+            assertEquals("8af9bc", toHex(encoded));
+        }
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/TaggedIntegerDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/TaggedIntegerDataTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("TaggedIntegerData")
+class TaggedIntegerDataTest {
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedIntegerData(1, -1);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedIntegerData(1, 32);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedIntegerData(-1, 2);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedIntegerData(16777216, 2);
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        TaggedIntegerData taggedIntegerData = new TaggedIntegerData(42, 2);
+
+        assertEquals(4, taggedIntegerData.length());
+        assertEquals(42, taggedIntegerData.getValue());
+        assertEquals(2, taggedIntegerData.getTag());
+    }
+
+    @Test
+    @DisplayName("Tagged integer data is decoded successfully")
+    void testDecode() {
+        {
+            byte[] encoded = fromHex("0200a411");
+
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNotNull(taggedIntegerData);
+            assertEquals(42_001, taggedIntegerData.getValue());
+            assertEquals(2, taggedIntegerData.getTag());
+        }
+        {
+            byte[] encoded = fromHex("0000a411");
+
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNotNull(taggedIntegerData);
+            assertEquals(42_001, taggedIntegerData.getValue());
+            assertEquals(0, taggedIntegerData.getTag());
+        }
+        {
+            byte[] encoded = fromHex("1f00a411");
+
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNotNull(taggedIntegerData);
+            assertEquals(42_001, taggedIntegerData.getValue());
+            assertEquals(31, taggedIntegerData.getTag());
+        }
+    }
+
+    @Test
+    @DisplayName("Tagged integer data is encoded successfully")
+    void testEncode() {
+        {
+            byte[] encoded = TaggedIntegerData.Codec.INSTANCE.encode(null, null, new TaggedIntegerData(42_001, 2));
+
+            assertEquals("0200a411", toHex(encoded));
+        }
+        {
+            byte[] encoded = TaggedIntegerData.Codec.INSTANCE.encode(null, null, new TaggedIntegerData(42_001, 0));
+
+            assertEquals("0000a411", toHex(encoded));
+        }
+        {
+            byte[] encoded = TaggedIntegerData.Codec.INSTANCE.encode(null, null, new TaggedIntegerData(42_001, 31));
+
+            assertEquals("1f00a411", toHex(encoded));
+        }
+    }
+
+    @Test
+    @DisplayName("Invalid tagged integer data is decoded into null")
+    void testDecodeInvalidLength() {
+        {
+            // Too few bytes
+            byte[] encoded = fromHex("00a411");
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNull(taggedIntegerData);
+        }
+        {
+            // Too many bytes
+            byte[] encoded = fromHex("0200a41100");
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNull(taggedIntegerData);
+        }
+        {
+            // Invalid tag (outside of [0, 31])
+            byte[] encoded = fromHex("ff00a411");
+            TaggedIntegerData taggedIntegerData = TaggedIntegerData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNull(taggedIntegerData);
+        }
+    }
+
+}

--- a/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/TaggedStringDataTest.java
+++ b/aaa4j-radius-core/src/test/java/org/aaa4j/radius/core/attribute/TaggedStringDataTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 The AAA4J-RADIUS Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.aaa4j.radius.core.attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.aaa4j.radius.core.Utils.fromHex;
+import static org.aaa4j.radius.core.Utils.toHex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("TaggedStringData")
+class TaggedStringDataTest {
+
+    @Test
+    @DisplayName("Constructor validates arguments")
+    void testConstructor() {
+        assertThrows(NullPointerException.class, () -> {
+            new TaggedStringData(null, 2);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedStringData(new byte[3], 32);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TaggedStringData(new byte[3], -1);
+        });
+    }
+
+    @Test
+    @DisplayName("Getters return the correct values")
+    void testGetters() {
+        TaggedStringData taggedStringData = new TaggedStringData(fromHex("8af9bc"), 31);
+
+        assertEquals(4, taggedStringData.length());
+        assertEquals("8af9bc", toHex(taggedStringData.getValue()));
+        assertEquals(31, taggedStringData.getTag());
+    }
+
+    @Test
+    @DisplayName("Tagged string data is decoded successfully")
+    void testDecode() {
+        byte[] encoded = fromHex("028af9bc");
+
+        TaggedStringData taggedStringData = TaggedStringData.Codec.INSTANCE.decode(null, null, encoded);
+
+        assertNotNull(taggedStringData);
+        assertEquals("8af9bc", toHex(taggedStringData.getValue()));
+        assertEquals(2, taggedStringData.getTag());
+    }
+
+    @Test
+    @DisplayName("Tagged string data is encoded successfully")
+    void testEncode() {
+        TaggedStringData taggedStringData = new TaggedStringData(fromHex("8af9bc"), 2);
+        byte[] encoded = TaggedStringData.Codec.INSTANCE.encode(null, null, taggedStringData);
+
+        assertEquals("028af9bc", toHex(encoded));
+    }
+
+    @Test
+    @DisplayName("Invalid tagged string data is decoded into null")
+    void testDecodeInvalidLength() {
+        {
+            // Too few bytes
+            byte[] encoded = fromHex("");
+            TaggedStringData taggedStringData = TaggedStringData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNull(taggedStringData);
+        }
+        {
+            // Invalid tag (outside of [0, 31])
+            byte[] encoded = fromHex("ff8af9bc");
+            TaggedStringData taggedStringData = TaggedStringData.Codec.INSTANCE.decode(null, null, encoded);
+
+            assertNull(taggedStringData);
+        }
+    }
+
+}


### PR DESCRIPTION
Added tagged types (`TaggedIntegerData`, `TaggedString`, `OptionalTaggedString`) required for RFC 2868 attributes.